### PR TITLE
Change GKE config to private

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,21 +26,6 @@ When following this  practice, before deployment create two projects and note do
 ### Classifier Access
 Classifier is currently in Preview. Early access can be granted using this [form](https://docs.google.com/forms/d/e/1FAIpQLSfDuC9bGyEwnseEYIC3I2LvNjzz-XZ2n1RS4X5pnIk2eSbk3A/viewform), so that Project is whitelisted.
 
-### GCP Organization policy
-
-Run the following commands to update Organization policies (Required for managed environments such as Argolis):
-```
-ORGANIZATION_ID=$(gcloud organizations list --format="value(name)")
-gcloud resource-manager org-policies disable-enforce constraints/compute.requireOsLogin --organization=$ORGANIZATION_ID
-gcloud resource-manager org-policies delete constraints/compute.vmExternalIpAccess --organization=$ORGANIZATION_ID
-```
-
-If you have multiple Organizations, set the ORGANIZATION_ID manually to the Organization ID
-
-Or, change the following Organization policy constraints in [GCP Console](https://console.cloud.google.com/iam-admin/orgpolicies)
-- constraints/compute.requireOsLogin - Enforced Off
-- constraints/compute.vmExternalIpAccess - Allow All
-
 ### Using Shared Virtual Private Cloud (VPC) for the deployment
 
 As is often the case in real-world configurations, this blueprint accepts as input an existing [Shared-VPC](https://cloud.google.com/vpc/docs/shared-vpc) via the `network_config` variable inside [terraform.tfvars](terraform/environments/dev/terraform.tfvars).
@@ -82,10 +67,14 @@ Note, If you do not have a custom domain, leave a dummy one `mydomain.com` (need
 >  region = "us-central1"
 > }
 >```
->  
+> When the **default GKE Control Plane CIDR Range (172.16.0.0/28) overlaps** with your network:
+> - Edit `terraform.tfvars` in the editor, uncomment `master_ipv4_cidr_block` and fill in the value of the GKE Control Plane CIDR /28 range:
+> ```shell
+> master_ipv4_cidr_block = "MASTER.CIDR/28.HERE"
+> ```
+>
 > For the **Reserved External IP**:
 > - Edit `terraform.tfvars` in the editor,  uncomment `cda_external_ip` and fill in the value of the reserved IP address (without http(s) prefix):
->
 > ```
 > cda_external_ip = "IP.ADDRESS.HERE"
 > ```

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -129,6 +129,8 @@ module "vpc_network" {
   subnetwork                = var.subnetwork
   secondary_ranges_pods     = var.secondary_ranges_pods
   secondary_ranges_services = var.secondary_ranges_services
+  master_cidr_ranges        = ["${var.master_ipv4_cidr_block}"]
+  node_pools_tags           = ["gke-${var.cluster_name}"]
 }
 
 module "gke" {
@@ -143,6 +145,7 @@ module "gke" {
   network_project_id        = local.network_config.host_project
   secondary_ranges_pods     = local.network_config.gke_secondary_ranges.pods
   secondary_ranges_services = local.network_config.gke_secondary_ranges.services
+  master_ipv4_cidr_block    = var.master_ipv4_cidr_block
   region                    = var.region
   min_node_count            = 1
   max_node_count            = 10
@@ -154,7 +157,7 @@ module "gke" {
   service_account_name = var.service_account_name_gke
 
   # See latest stable version at https://cloud.google.com/kubernetes-engine/docs/release-notes-stable
-  kubernetes_version = "1.23.13-gke.900"
+  kubernetes_version = "1.24.9-gke.3200"
 
 }
 

--- a/terraform/environments/dev/terraform.sample.tfvars
+++ b/terraform/environments/dev/terraform.sample.tfvars
@@ -9,3 +9,4 @@
 //  region = "us-central1"
 //}
 //cda_external_ip = "IP.ADDRESS.HERE"
+//master_ipv4_cidr_block = "MASTER.CIDR/28.HERE" 

--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -174,3 +174,9 @@ variable "service_account_name_gke" {
   # This service account will be created in both GCP and GKE, and will be
   # used for workload federation in all microservices.
 }
+
+variable "master_ipv4_cidr_block" {
+  type        = string
+  description = "The IP range in CIDR notation to use for the hosted master network"
+  default     = "172.16.0.0/28"
+}

--- a/terraform/modules/gke/main.tf
+++ b/terraform/modules/gke/main.tf
@@ -34,6 +34,8 @@ module "gke_cluster" {
   ip_range_pods              = var.secondary_ranges_pods
   ip_range_services          = var.secondary_ranges_services
   http_load_balancing        = true
+  enable_private_nodes       = var.enable_private_nodes
+  master_ipv4_cidr_block     = var.master_ipv4_cidr_block
   network_project_id         = var.network_project_id
   identity_namespace         = "enabled"
   horizontal_pod_autoscaling = true

--- a/terraform/modules/gke/variables.tf
+++ b/terraform/modules/gke/variables.tf
@@ -97,3 +97,14 @@ variable "service_account_name" {
   type        = string
   description = "Google Service Account name"
 }
+
+variable "enable_private_nodes" {
+  type        = bool
+  description = "Whether nodes have internal IP addresses only"
+  default     = true
+}
+
+variable "master_ipv4_cidr_block" {
+  type        = string
+  description = "The IP range in CIDR notation to use for the hosted master network"
+}

--- a/terraform/modules/vpc_network/variables.tf
+++ b/terraform/modules/vpc_network/variables.tf
@@ -47,3 +47,19 @@ variable "secondary_ranges_services" {
     ip_cidr_range = string
   })
 }
+
+variable "source_subnetwork_ip_ranges_to_nat" {
+  type        = string
+  description = "Defaults to ALL_SUBNETWORKS_ALL_IP_RANGES. How NAT should be configured per Subnetwork. Valid values include: ALL_SUBNETWORKS_ALL_IP_RANGES, ALL_SUBNETWORKS_ALL_PRIMARY_IP_RANGES, LIST_OF_SUBNETWORKS. Changing this forces a new NAT to be created."
+  default     = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+}
+
+variable "master_cidr_ranges" {
+  type        = list(any)
+  description = "Master/Control Plan CIDR range to allow communication with GKE Node"
+}
+
+variable "node_pools_tags" {
+  type        = list(any)
+  description = "GKE Nodes tags to allow communication with Master/Control Plan"
+}


### PR DESCRIPTION
The PR include the following changes:

- **GKE to private** (and dependencies like: NAT, router, Master IP range and Firewall rules) in order to allow the following org policies to be enforced:
-- constraints/compute.requireOsLogin
-- constraints/compute.vmExternalIpAccess

- **README.md** to remove org policies configuration

- **GKE version** to a supported and stable one.
-- kubernetes_version = "1.24.9-gke.3200"

_**PS: This setup has not been tested with Shared VPC**_