### PR TITLE
Update deployment scripts to deploy CDA to a specific region

### DIFF
--- a/SET
+++ b/SET
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 export BASE_DIR=$(pwd)
-export REGION=us-central1
+export REGION="us-central1"
 
 # Shared VPC Config
 export NETWORK=cda-vpc
@@ -43,13 +43,20 @@ export TF_VAR_api_domain=$API_DOMAIN
 export TF_VAR_project_id=$PROJECT_ID
 export TF_VAR_docai_project_id=${DOCAI_PROJECT_ID:-$PROJECT_ID}
 export TF_BUCKET_NAME="${PROJECT_ID}-tfstate"
-export TF_BUCKET_LOCATION="us"
+export TF_BUCKET_LOCATION=$REGION
 export TF_VAR_config_bucket="${PROJECT_ID}-config"
 export TF_VAR_region=$REGION
 export TF_VAR_iap_secret_name="${IAP_SECRET_NAME}"
 export TF_VAR_dataset_id="${BIGQUERY_DATASET}"
 export TF_VAR_service_account_name_gke=${SA_GKE}
 export TF_VAR_repo_name="ar-artifacts"
+# For regional CDA deployment, uncomment the following code.
+#export TF_VAR_firestore_location=$REGION
+#export TF_VAR_storage_location=$REGION
+#export TF_VAR_dataset_location=$REGION
+#export TF_VAR_eventarc_location=$REGION
+#export TF_VAR_docai_location="us"
+
 # used by Microservices
 export CONFIG_BUCKET=${TF_VAR_config_bucket}
 export DEBUG=True

--- a/common/skaffold.yaml
+++ b/common/skaffold.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: skaffold/v2beta12
+apiVersion: skaffold/v4beta11
 kind: Config
 metadata:
   name: common

--- a/deploy.sh
+++ b/deploy.sh
@@ -54,6 +54,13 @@ else
   gsutil cp "gs://${TF_VAR_config_bucket}/.env" "${DIR}/microservices/adp_ui/.env"  | tee -a "$LOG"
 fi
 
+CLOUD_BUILD_REGION="${REGION:-"us"}"
+echo "Set CLOUD_BUILD_REGION as $CLOUD_BUILD_REGION"
+
+# Create GCS bucket for skaffold in $CLOUD_BUILD_REGION, since Scaffold
+# automatically tries to create $PROJECT_ID_cloudbuild bucket in US region
+gsutil mb -l $CLOUD_BUILD_REGION gs://${PROJECT_ID}_cloudbuild
+
 
 skaffold run -p "$ENV" | tee -a "$LOG"
 

--- a/terraform/modules/bigquery/bigquery.tf
+++ b/terraform/modules/bigquery/bigquery.tf
@@ -21,7 +21,7 @@ resource "google_bigquery_dataset" "data_set" {
   dataset_id    = var.dataset_id
   friendly_name = "Validation Dataset"
   description   = "BQ dataset for validation process"
-  location      = "US"
+  location      = var.location
   labels = {
     goog-packaged-solution = "prior-authorization"
   }

--- a/terraform/modules/bigquery/variables.tf
+++ b/terraform/modules/bigquery/variables.tf
@@ -25,3 +25,9 @@ variable "dataset_id" {
   description = "Dataset ID"
 }
 
+variable "location" {
+  type        = string
+  description = "The geographic location where the bigquery dataset should reside"
+  default     = "US"
+}
+

--- a/terraform/modules/cloudbuild/main.tf
+++ b/terraform/modules/cloudbuild/main.tf
@@ -17,7 +17,7 @@
 
 resource "google_storage_bucket" "cloudbuild-logs" {
   name          = "${var.project_id}-cloudbuild-logs"
-  location      = var.storage_multiregion
+  location      = var.storage_location
   storage_class = "NEARLINE"
 
   uniform_bucket_level_access = true

--- a/terraform/modules/cloudbuild/variables.tf
+++ b/terraform/modules/cloudbuild/variables.tf
@@ -20,6 +20,8 @@ variable "project_id" {
   description = "project ID"
 }
 
-variable "storage_multiregion" {
+variable "storage_location" {
   type        = string
+  description = "GCS bucket location for cloudbuild-logs"
+  default     = "us"
 }

--- a/terraform/modules/cloudrun/main.tf
+++ b/terraform/modules/cloudrun/main.tf
@@ -62,6 +62,10 @@ resource "null_resource" "build-common-image" {
     src_hash = data.archive_file.common-zip.output_sha
   }
 
+  depends_on = [
+    google_storage_bucket.log-bucket,
+  ]
+
   provisioner "local-exec" {
     working_dir = "../../../common"
     command = join(" ", [
@@ -69,6 +73,7 @@ resource "null_resource" "build-common-image" {
       "--config=cloudbuild.yaml",
       "--gcs-source-staging-dir=gs://${var.project_id}-${var.name}-log/cblogs",
       "--default-buckets-behavior=regional-user-owned-bucket",
+      "--region=${var.region}",
       join("", [
         "--substitutions=",
         "_PROJECT_ID='${var.project_id}',",
@@ -102,6 +107,8 @@ resource "null_resource" "build-cloudrun-image" {
       "gcloud builds submit",
       "--config=cloudbuild.yaml",
       "--gcs-log-dir=gs://${var.project_id}-${var.name}-log",
+      "--default-buckets-behavior=regional-user-owned-bucket",
+      "--region=${var.region}",
       join("", [
         "--substitutions=",
         "_PROJECT_ID='${var.project_id}',",

--- a/terraform/modules/docai/main.tf
+++ b/terraform/modules/docai/main.tf
@@ -16,7 +16,7 @@
  */
 
 resource "google_document_ai_processor" "processors" {
-  location     = var.multiregion
+  location     = var.location
   for_each     = var.processors
   display_name = each.key
   type         = each.value
@@ -27,7 +27,7 @@ resource "google_document_ai_processor" "processors" {
 output "parser_config" {
   value = {
     for k, processor in google_document_ai_processor.processors : processor.display_name => {
-      location     = var.multiregion
+      location     = var.location
       parser_name  = processor.display_name
       parser_type  = processor.type
       processor_id = processor.id

--- a/terraform/modules/docai/variables.tf
+++ b/terraform/modules/docai/variables.tf
@@ -24,7 +24,8 @@ variable "processors" {
   type        = any
 }
 
-variable "multiregion" {
-  type    = string
-  default = "us"
+variable "location" {
+  type        = string
+  description = "The location of the docai parser"
+  default     = "us"
 }

--- a/terraform/modules/eventarc/main.tf
+++ b/terraform/modules/eventarc/main.tf
@@ -21,7 +21,7 @@ resource "google_eventarc_trigger" "pipeline-topic-trigger" {
   provider        = google
   name            = "startpipeline-topic-trigger"
   project         = var.project_id
-  location        = var.region
+  location        = var.location
   service_account = var.service_account_email
   labels = {
     goog-packaged-solution = "prior-authorization"

--- a/terraform/modules/eventarc/variables.tf
+++ b/terraform/modules/eventarc/variables.tf
@@ -46,9 +46,9 @@ variable "cloudrun_endpoint" {
   description = "cloudrun_endpoint"
 }
 
-variable "region" {
+variable "location" {
   type        = string
-  description = "region"
+  description = "Eventarc trigger location"
 }
 
 variable "service_account_email" {

--- a/terraform/modules/firebase/main.tf
+++ b/terraform/modules/firebase/main.tf
@@ -20,13 +20,13 @@
 resource "google_app_engine_application" "firebase_init" {
   provider      = google
   project       = var.project_id
-  location_id   = var.firestore_region
+  location_id   = var.firestore_location
   database_type = "CLOUD_FIRESTORE"
 }
 
 resource "google_storage_bucket" "firestore-backup-bucket" {
   name          = "${var.project_id}-firestore-backup"
-  location      = var.storage_multiregion
+  location      = var.storage_location
   storage_class = "NEARLINE"
   labels = {
     goog-packaged-solution = "prior-authorization"

--- a/terraform/modules/firebase/variables.tf
+++ b/terraform/modules/firebase/variables.tf
@@ -20,7 +20,7 @@ variable "project_id" {
   description = "project ID"
 }
 
-variable "firestore_region" {
+variable "firestore_location" {
   type        = string
   description = "Firestore Region - must be app_engine region"
   # options for firestore: https://cloud.google.com/appengine/docs/locations
@@ -28,7 +28,8 @@ variable "firestore_region" {
   default     = "us-central"
 }
 
-variable "storage_multiregion" {
-  type    = string
-  default = "us"
+variable "storage_location" {
+  type        = string
+  description = "GCS bucket location for firestore-backup-bucket"
+  default     = "us"
 }

--- a/terraform/stages/foundation/variables.tf
+++ b/terraform/stages/foundation/variables.tf
@@ -64,9 +64,9 @@ variable "region" {
   }
 }
 
-variable "firestore_region" {
+variable "firestore_location" {
   type        = string
-  description = "Firestore Region"
+  description = "Firestore Location"
   default     = "us-central"
 }
 
@@ -74,11 +74,6 @@ variable "dataset_location" {
   type        = string
   description = "BigQuery Dataset location"
   default     = "US"
-}
-
-variable "multiregion" {
-  type    = string
-  default = "us"
 }
 
 variable "env" {
@@ -211,4 +206,22 @@ variable "cda_external_ui" {
   type        = bool
   description = "Expose UI to public internet"
   default     = false
+}
+
+variable "storage_location" {
+  type        = string
+  description = "GCS buckets location"
+  default     = "us"
+}
+
+variable "eventarc_location" {
+  type        = string
+  description = "Eventarc trigger location"
+  default     = "us-central1"
+}
+
+variable "docai_location" {
+  type        = string
+  description = "DocAI parser location"
+  default     = "us"
 }


### PR DESCRIPTION
Update terraform scripts to deploy CDA to a specific region
- Able to select a region by updating SET file
  - US(us-central and us) is used by default
- Verified with following patterns:
  - Default configuration(us-central, us)
  - Updated configuration (eu for docai and asia-east2 for the rest) and an organization policy (gcp.resourceLocations)